### PR TITLE
Arreglado bug cuando se pasaba listing no existente al make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ $(listings):
 	$(MAKE) --directory=$@
 
 %:
-	$(MAKE) --directory=$($@)
+	$(if $($@), $(MAKE) --directory=$($@), $(error comando o listing "$@" no existe))
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
Basicamente lo que paso fue que al pasar un listing no existente, se devolvio vacio, lo que a su vez fue pasado a la opcion de directorio. Esto entonces causaba un error diciendo que se paso string vacio cuando en realidad el usuario paso solo algo equivocado.